### PR TITLE
feat: implement rotary position embedding layer

### DIFF
--- a/tests/layers/test_rotary_embedding.py
+++ b/tests/layers/test_rotary_embedding.py
@@ -1,0 +1,43 @@
+import torch
+
+from tinylm.layers.rotary_embedding import get_rotary_embedding
+from tinylm.testutil import allclose
+
+
+def test_rotary_embedding_correctness():
+    batch_size = 2
+    head_size = 2
+    seq_len = 2
+    num_heads = 1
+    device = torch.device("cpu")
+    dtype = torch.bfloat16
+
+    rotary_emb = get_rotary_embedding(
+        head_size=head_size,
+        rotary_dim=head_size,
+        max_position_embeddings=seq_len,
+        base=1000.0,
+    )
+    rotary_emb = rotary_emb.to(device=device)
+
+    num_tokens = batch_size * seq_len
+    input_size = num_tokens * head_size * num_heads
+    shape = num_tokens, num_heads, head_size
+    pos = torch.arange(seq_len, dtype=torch.long, device=device).repeat(batch_size)
+    q = 1 + torch.arange(input_size, dtype=dtype, device=device).reshape(shape)
+    k = 16 - torch.arange(input_size, dtype=dtype, device=device).reshape(shape)
+
+    q_rotated, k_rotated = rotary_emb(pos, q, k)
+
+    q_rotated_ref = torch.tensor(
+        [[[1.0000, 2.0000]], [[-1.7422, 4.6875]], [[5.0000, 6.0000]], [[-2.9531, 10.1875]]],
+        dtype=dtype,
+        device=device,
+    )
+    k_rotated_ref = torch.tensor(
+        [[[16.0000, 15.0000]], [[-3.3750, 18.7500]], [[12.0000, 11.0000]], [[-2.1719, 13.2500]]],
+        dtype=dtype,
+        device=device,
+    )
+    assert allclose(q_rotated, q_rotated_ref)
+    assert allclose(k_rotated, k_rotated_ref)

--- a/tinylm/layers/rotary_embedding.py
+++ b/tinylm/layers/rotary_embedding.py
@@ -1,0 +1,68 @@
+from functools import lru_cache
+
+import torch
+from torch import nn
+
+
+class RotaryEmbedding(nn.Module):
+    def __init__(
+        self,
+        head_size: int,
+        rotary_dim: int,
+        max_position_embeddings: int,
+        base: float,
+    ) -> None:
+        super().__init__()
+        self.head_size = head_size
+
+        # build the cosine and sine cache
+        inv_freq = 1.0 / (base ** (torch.arange(0, rotary_dim, 2).float() / rotary_dim))
+        t = torch.arange(max_position_embeddings, dtype=torch.float)
+        freqs = torch.outer(t, inv_freq)
+        cos, sin = freqs.cos(), freqs.sin()
+        cache = torch.cat((cos, sin), dim=-1)
+        self.register_buffer("cos_sin_cache", cache, persistent=False)
+
+    def _apply_rotary_embedding(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ) -> torch.Tensor:
+        cos = cos.unsqueeze(-2)
+        sin = sin.unsqueeze(-2)
+        # Note that this conversion is different from other frameworks such as vLLM or SGLang.
+        # We added float32 conversion because float32 is required for inputs with long context.
+        x1, x2 = torch.chunk(x.float(), 2, dim=-1)
+        y1 = x1 * cos - x2 * sin
+        y2 = x1 * sin + x2 * cos
+        return torch.cat((y1, y2), dim=-1).to(x.dtype)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        cos_sin = self.cos_sin_cache[positions]
+        cos, sin = cos_sin.chunk(2, dim=-1)
+
+        q_rotated = self._apply_rotary_embedding(query, cos, sin)
+        k_rotated = self._apply_rotary_embedding(key, cos, sin)
+
+        return q_rotated, k_rotated
+
+
+@lru_cache(maxsize=1)
+def get_rotary_embedding(
+    head_size: int,
+    rotary_dim: int,
+    max_position_embeddings: int,
+    base: float,
+) -> RotaryEmbedding:
+    return RotaryEmbedding(
+        head_size=head_size,
+        rotary_dim=rotary_dim,
+        max_position_embeddings=max_position_embeddings,
+        base=base,
+    )

--- a/tinylm/layers/rotary_embedding.py
+++ b/tinylm/layers/rotary_embedding.py
@@ -5,6 +5,8 @@ from torch import nn
 
 
 class RotaryEmbedding(nn.Module):
+    cos_sin_cache: torch.Tensor
+
     def __init__(
         self,
         head_size: int,
@@ -44,7 +46,7 @@ class RotaryEmbedding(nn.Module):
         query: torch.Tensor,
         key: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        cos_sin = self.cos_sin_cache[positions]
+        cos_sin = self.cos_sin_cache.index_select(0, positions)
         cos, sin = cos_sin.chunk(2, dim=-1)
 
         q_rotated = self._apply_rotary_embedding(query, cos, sin)


### PR DESCRIPTION
Implement Rotary Postion Embedding (RoPE) layer with pure PyTorch API. This implementation comes with sine and cosine caching and float32 conversion for long context inputs.