### PR TITLE
refactor: skip NVIDIA-related tests if there is no CUDA devices

### DIFF
--- a/ci/nvidia.py
+++ b/ci/nvidia.py
@@ -30,4 +30,4 @@ def do_test():
         "cwd": REMOTE_ROOT_PATH,
     }
     subprocess.run("uv sync --group dev --compile-bytecode", **kwargs)
-    subprocess.run("TEST_NVIDIA=1 uv run --group dev poe test", **kwargs)
+    subprocess.run("uv run --group dev poe test", **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Generator
 
@@ -8,11 +10,23 @@ from tinylm.config import TinyLMConfig, get_config
 
 
 @pytest.fixture(scope="session")
-def is_nvidia() -> Generator[bool, None, None]:
-    flag = os.environ.get("TEST_NVIDIA", "0").lower() in ("1", "true")
-    if not flag:
-        pytest.skip("TEST_NVIDIA is not set to true; thus skip this test!")
-    yield True
+def is_nvidia() -> bool:
+    if skip := os.environ.get("SKIP_NVIDIA_TESTS"):
+        if skip.lower() in ("1", "true", "yes"):
+            return False
+    if shutil.which("nvidia-smi"):
+        try:
+            result = subprocess.run(
+                ["nvidia-smi", "--query-gpu=count", "--format=csv,noheader"],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            gpu_count = int(result.stdout.strip())
+            return gpu_count > 0
+        except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
+            return False
+    return False
 
 
 @pytest.fixture(scope="session")

--- a/tests/layers/test_activation.py
+++ b/tests/layers/test_activation.py
@@ -20,6 +20,9 @@ def test_GeluAndMul(
     is_nvidia: bool,
     config: TinyLMConfig,
 ) -> None:
+    if not is_nvidia:
+        pytest.skip("Skipping test on non-NVIDIA environment")
+
     x = torch.randn(batch_size, seq_len, 2 * dim).cuda().to(dtype)
     layer = GeluAndMul(approximate=approximate)
     expected_output = layer.forward_torch(x)

--- a/tests/layers/test_rotary_embedding.py
+++ b/tests/layers/test_rotary_embedding.py
@@ -1,15 +1,20 @@
+import pytest
 import torch
 
 from tinylm.layers.rotary_embedding import get_rotary_embedding
 from tinylm.testutil import allclose
 
 
-def test_rotary_embedding_correctness():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_rotary_embedding_correctness(device: str, is_nvidia: bool) -> None:
+    if not is_nvidia and device == "cuda":
+        pytest.skip("Skipping test on non-NVIDIA environment")
+
     batch_size = 2
     head_size = 2
     seq_len = 2
     num_heads = 1
-    device = torch.device("cpu")
+    device_ = torch.device(device)
     dtype = torch.bfloat16
 
     rotary_emb = get_rotary_embedding(
@@ -18,26 +23,26 @@ def test_rotary_embedding_correctness():
         max_position_embeddings=seq_len,
         base=1000.0,
     )
-    rotary_emb = rotary_emb.to(device=device)
+    rotary_emb = rotary_emb.to(device=device_)
 
     num_tokens = batch_size * seq_len
     input_size = num_tokens * head_size * num_heads
     shape = num_tokens, num_heads, head_size
-    pos = torch.arange(seq_len, dtype=torch.long, device=device).repeat(batch_size)
-    q = 1 + torch.arange(input_size, dtype=dtype, device=device).reshape(shape)
-    k = 16 - torch.arange(input_size, dtype=dtype, device=device).reshape(shape)
+    pos = torch.arange(seq_len, dtype=torch.long, device=device_).repeat(batch_size)
+    q = 1 + torch.arange(input_size, dtype=dtype, device=device_).reshape(shape)
+    k = 16 - torch.arange(input_size, dtype=dtype, device=device_).reshape(shape)
 
     q_rotated, k_rotated = rotary_emb(pos, q, k)
 
     q_rotated_ref = torch.tensor(
         [[[1.0000, 2.0000]], [[-1.7422, 4.6875]], [[5.0000, 6.0000]], [[-2.9531, 10.1875]]],
         dtype=dtype,
-        device=device,
+        device=device_,
     )
     k_rotated_ref = torch.tensor(
         [[[16.0000, 15.0000]], [[-3.3750, 18.7500]], [[12.0000, 11.0000]], [[-2.1719, 13.2500]]],
         dtype=dtype,
-        device=device,
+        device=device_,
     )
     assert allclose(q_rotated, q_rotated_ref)
     assert allclose(k_rotated, k_rotated_ref)


### PR DESCRIPTION
Currently, the tests requiring NVIDIA devices are disabled in default. To run the tests, we need to set `TEST_NVIDIA` environment variable to `1` or `yes`. This causes the lack of running validity checks in local development.

This PR makes the tests are running in default if there is at least one CUDA device. To skip the tests, the user set the `SKIP_NVIDIA_TESTS` environment variable to `1`, `true`, or `yes`.