### PR TITLE
feat: implement context to store current inference metadata

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,7 @@
+from tinylm.context import Context, current_context, get_context
+
+
+def test_context():
+    ctx = Context()
+    with current_context(ctx):
+        assert get_context() is ctx

--- a/tinylm/context.py
+++ b/tinylm/context.py
@@ -1,0 +1,28 @@
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Generator, Optional
+
+
+@dataclass
+class Context:
+    pass
+
+
+_current_context: Optional[Context] = None
+
+
+@contextmanager
+def current_context(context: Context) -> Generator[None, None, None]:
+    global _current_context
+    _prev_context = _current_context
+    _current_context = context
+    try:
+        yield
+    finally:
+        _current_context = _prev_context
+
+
+def get_context() -> Context:
+    if _current_context is None:
+        raise RuntimeError("No context is set. Use 'with with_context(...)' to set one.")
+    return _current_context


### PR DESCRIPTION
To handle current inference metadata such as offsets for the attention layer, we implement a simple context and its management functions.