### PR TITLE
refactor: rename TinyLMConfig to TinyLMTrainConfig

### DIFF
--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -1,1 +1,1 @@
-model_path: gghfez/gemma-3-4b-novision
+model_name: chiwanpark/TinyLM-Ko-0.5B

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from typing import Generator
 
 import pytest
 
-from tinylm.config import TinyLMConfig, get_config
+from tinylm.config import TinyLMTrainConfig, get_config
 
 
 @pytest.fixture(scope="session")
@@ -30,6 +30,6 @@ def is_nvidia() -> bool:
 
 
 @pytest.fixture(scope="session")
-def config() -> Generator[TinyLMConfig, None, None]:
+def train_config() -> Generator[TinyLMTrainConfig, None, None]:
     path = Path(__file__).parent / "config.yaml"
     yield get_config(path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,11 @@
-from tinylm.config import TinyLMConfig, config_override, get_config
+from tinylm.config import TinyLMTrainConfig, config_override, get_config
 
 
-def test_config(config: TinyLMConfig):
-    assert config.model_path == "gghfez/gemma-3-4b-novision"
+def test_train_config(train_config: TinyLMTrainConfig):
+    assert train_config.model_name == "chiwanpark/TinyLM-Ko-0.5B"
 
 
-def test_config_override(config: TinyLMConfig):
-    with config_override(config, model_path="google/gemma-3-1b-it"):
+def test_train_config_override(train_config: TinyLMTrainConfig):
+    with config_override(train_config, model_name="google/gemma-3-1b-it"):
         config = get_config()
-        assert config.model_path == "google/gemma-3-1b-it"
+        assert config.model_name == "google/gemma-3-1b-it"

--- a/tinylm/config.py
+++ b/tinylm/config.py
@@ -6,16 +6,16 @@ from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic_settings.sources import YamlConfigSettingsSource
 
-_config: Optional["TinyLMConfig"] = None
+_config: Optional["TinyLMTrainConfig"] = None
 
 
-class TinyLMConfig(BaseSettings):
+class TinyLMTrainConfig(BaseSettings):
     model_config = SettingsConfigDict(
         extra="forbid",
     )
 
-    model_path: str = Field()
-    """The path to the language model."""
+    model_name: str = Field()
+    """Name of the model to be trained."""
 
     @classmethod
     def from_yaml(cls, path: Path) -> Self:
@@ -27,7 +27,7 @@ class TinyLMConfig(BaseSettings):
 
 
 @contextmanager
-def config_override(config: Optional[TinyLMConfig] = None, **kwargs: Any) -> Generator[None, None, None]:
+def config_override(config: Optional[TinyLMTrainConfig] = None, **kwargs: Any) -> Generator[None, None, None]:
     if not config:
         config = get_config()
     data = config.model_dump()
@@ -35,17 +35,17 @@ def config_override(config: Optional[TinyLMConfig] = None, **kwargs: Any) -> Gen
 
     global _config
     config_old = _config
-    _config = TinyLMConfig.from_dict(data)
+    _config = TinyLMTrainConfig.from_dict(data)
     try:
         yield
     finally:
         _config = config_old
 
 
-def get_config(path: Optional[Path] = None) -> TinyLMConfig:
+def get_config(path: Optional[Path] = None) -> TinyLMTrainConfig:
     global _config
     if path is not None:
-        _config = TinyLMConfig.from_yaml(path)
+        _config = TinyLMTrainConfig.from_yaml(path)
     if not _config:
         raise ValueError("Configuration not set. Please provide a path to the configuration.")
     return _config


### PR DESCRIPTION
We first focus on implementing training codes; thus, we rename `TinyLMConfig` class to `TinyLMTrainConfig`. We will add `TinyLMServeConfig` later.